### PR TITLE
Added param to strain import for providing dsc_phenotypes file

### DIFF
--- a/lib/Modware/Import/Command/dictystrain2chado.pm
+++ b/lib/Modware/Import/Command/dictystrain2chado.pm
@@ -20,13 +20,23 @@ has data => (
     default => sub {
         [   qw/characteristics publications inventory genotype phenotype props parent plasmid/
         ];
-    }
+    },
+    documentation =>
+        'Data to be imported. Default all (characteristics, publications, inventory, genotype, phenotype, props, parent, plasmid)'
+);
+
+has dsc_phenotypes => (
+    is            => 'rw',
+    isa           => 'Str',
+    default       => undef,
+    documentation => 'File with corrected stockcenter phenotypes'
 );
 
 has mock_pubs => (
-    is      => 'rw',
-    isa     => 'Bool',
-    default => 0,
+    is            => 'rw',
+    isa           => 'Bool',
+    default       => 0,
+    documentation => 'Boolean to create mock publications. Default 0'
 );
 
 sub execute {
@@ -56,6 +66,10 @@ sub execute {
     foreach my $data ( @{ $self->data } ) {
         my $input_file = catfile( $self->data_dir, $prefix . $data . '.tsv' );
         my $import_data = 'import_' . $data;
+        if ( $data eq 'phenotype' ) {
+            $importer->$import_data( $input_file, $self->dsc_phenotypes );
+            next;
+        }
         $importer->$import_data($input_file);
     }
 


### PR DESCRIPTION
- Added support for loading DSC phenotypes
- Pass path to [file](https://github.com/dictyBase/migration-data/blob/master/strain/DSC_phenotypes_import.tsv) to `--dsc_phenotypes`

**Note:**
- The [original annotated data](https://github.com/dictyBase/migration-data/blob/master/strain/DSC_phenotypes_orig.tsv) is in a slightly different format than required for [import](https://github.com/dictyBase/migration-data/blob/master/strain/DSC_phenotypes_import.tsv)
