### PR TITLE
Added the feature to import fixed strain-plasmids

### DIFF
--- a/lib/Modware/Import/Command/dictystrain2chado.pm
+++ b/lib/Modware/Import/Command/dictystrain2chado.pm
@@ -28,8 +28,13 @@ has data => (
 has dsc_phenotypes => (
     is            => 'rw',
     isa           => 'Str',
-    default       => undef,
     documentation => 'File with corrected stockcenter phenotypes'
+);
+
+has strain_plasmid => (
+    is            => 'rw',
+    isa           => 'Str',
+    documentation => 'File with strain-plasmids mapped to real plasmids'
 );
 
 has mock_pubs => (
@@ -68,6 +73,10 @@ sub execute {
         my $import_data = 'import_' . $data;
         if ( $data eq 'phenotype' ) {
             $importer->$import_data( $input_file, $self->dsc_phenotypes );
+            next;
+        }
+        if ( $data eq 'plasmid' ) {
+            $importer->$import_data( $input_file, $self->strain_plasmid );
             next;
         }
         $importer->$import_data($input_file);


### PR DESCRIPTION
- This feature imports data for fixed strain-plasmids
  - There are plasmids associated with strains that are not real plasmids or link to real plasmids
- The data has been fixed manually and is available [here](https://github.com/dictyBase/migration-data/blob/master/plasmid/Strain_plasmid.tsv).

_Note: Remove header line for import_
